### PR TITLE
Further Simplify the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Small utility library to run controlled experiments (i.e. A/B/n tests) in javasc
 ![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg)
 
 -  No external dependencies
--  Lightweight and fast (3Kb gzipped)
+-  Lightweight and fast (<3Kb gzipped)
 -  No HTTP requests, everything is defined and evaluated locally
 -  Supports both browser and NodeJS environments
 -  Written in Typescript with 100% test coverage
 -  Advanced user and page targeting
--  Use your existing event tracking (Segment, Snowplow, Mixpanel, custom)
+-  Use your existing event tracking (GA, Segment, Snowplow, Mixpanel, custom)
 -  Adjust variation weights and targeting without deploying new code
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ interface Experiment {
     // How to weight traffic between variations. Array of floats that add to 1.
     weights?: number[];
     // "running" is always active, "draft" is only active during QA. "stopped" is only active when forcing a winning variation
-    status: "draft" | "running" | "stopped";
+    status?: "draft" | "running" | "stopped";
     // What percent of users should be included in the experiment. Float from 0 to 1.
     coverage?: number;
     // Users can only be included in this experiment if the current URL matches this regex
@@ -76,7 +76,7 @@ interface Experiment {
     // specified variation index
     force?: number;
     // If true, use anonymous id for assigning, otherwise use logged-in user id
-    anon: boolean;
+    anon?: boolean;
 }
 ```
 
@@ -192,6 +192,37 @@ const {inExperiment, value} = user.experiment({
 
 If the user does not match the targeting rules, `inExperiment` will be false and they will be assigned variation index `0`.
 
+## Overriding Weights and Targeting
+
+It's common practice to adjust experiment settings after a test is live.  For example, slowly ramping up traffic, stopping a test automatically if guardrail metrics go down, or rolling out a winning variation to 100% of users.
+
+Instead of constantly changing your code, you can use client overrides.  For example, to roll out a winning variation to 100% of users:
+```ts
+client.overrides.set("experiment-key", {
+    status: 'stopped',
+    // Force variation index 1
+    force: 1
+});
+```
+
+The full list of experiment properties you can override is:
+*  status
+*  force
+*  weights
+*  coverage
+*  targeting
+*  url
+
+This data structure can be easily seralized and stored in a database or returned from an API.  There is a small helper function if you have all of your overrides in a single JSON object:
+
+```ts
+client.importOverrides({
+    "key1": {...},
+    "key2": {...},
+    ...
+})
+```
+
 ## Tracking Metrics and Analyzing Results
 
 This library only handles assigning variations to users.  The 2 other parts required for an A/B testing platform are Tracking and Analysis.
@@ -230,40 +261,9 @@ For analysis, there are a few options:
 *  Online A/B testing calculators
 *  Built-in A/B test analysis in Mixpanel/Amplitude
 *  Python or R libraries and a Jupyter Notebook
-*  Use the [Growth Book App](https://www.growthbook.io)
+*  The [Growth Book App](https://www.growthbook.io) (more info below)
 
-## Overriding Weights and Targeting
-
-It's common practice to adjust experiment settings after a test is live.  For example, slowly ramping up traffic, stopping a test automatically if guardrail metrics go down, or rolling out a winning variation to 100% of users.
-
-Instead of constantly changing your code, you can use client overrides.  For example, to roll out a winning variation to 100% of users:
-```ts
-client.overrides.set("experiment-key", {
-    status: 'stopped',
-    // Force variation index 1
-    force: 1
-});
-```
-
-The full list of experiment properties you can override is:
-*  status
-*  force
-*  weights
-*  coverage
-*  targeting
-*  url
-
-This data structure can be easily seralized and stored in a database or returned from an API.  There is a small helper function if you have all of your overrides in a single JSON object:
-
-```ts
-client.importOverrides({
-    "key1": {...},
-    "key2": {...},
-    ...
-})
-```
-
-## The Growth Book App
+### The Growth Book App
 
 Managing experiments and analyzing results at scale can be complicated, which is why we built the [Growth Book App](https://www.growthbook.io).  It's completely optional, but definitely worth checking out.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Small utility library to run controlled experiments (i.e. A/B/n tests) in javasc
 -  Lightweight and fast (3Kb gzipped)
 -  No HTTP requests, everything is defined and evaluated locally
 -  Supports both browser and NodeJS environments
--  Written in Typescript with an extensive test suite
+-  Written in Typescript with 100% test coverage
 -  Advanced user and page targeting
 -  Use your existing event tracking (Segment, Snowplow, Mixpanel, custom)
 -  Adjust variation weights and targeting without deploying new code
@@ -119,7 +119,7 @@ Below are all of the available options:
 With a Single Page App (SPA), you need to update the client on navigation in order to target tests based on URL:
 
 ```ts
-client.setUrl(newUrl);
+client.config.url = newUrl;
 ```
 
 Doing this with Next.js for example, will look like this:
@@ -128,7 +128,7 @@ export default function MyApp({ Component, pageProps }) {
   const router = useRouter()
 
   useEffect(() => {
-    const onChange = (newUrl) => client.setUrl(newUrl);
+    const onChange = (newUrl) => client.config.url = newUrl;
     router.events.on('routeChangeComplete', onChange);
     return () => router.events.off('routeChangeComplete', onChange);
   }, [])

--- a/package.json
+++ b/package.json
@@ -57,8 +57,5 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.0.3",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {
-    "dom-mutator": "^0.3.1"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,10 +43,6 @@ export default class GrowthBookClient {
     this._enabled = false;
   }
 
-  setUrl(url: string) {
-    this.config.url = url;
-  }
-
   user({ anonId, id, attributes }: UserArg): GrowthBookUser {
     const user = new GrowthBookUser(
       id || '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,4 @@
-import { DeclarativeMutation } from 'dom-mutator';
-
 export interface UserAttributes {
-  [key: string]: unknown;
-}
-export interface ExperimentData {
-  [key: string]: unknown[];
-}
-export interface VariationData {
   [key: string]: unknown;
 }
 
@@ -22,36 +14,23 @@ export type UserArg =
       attributes?: UserAttributes;
     };
 
-export interface ExperimentResults {
-  variation: number;
-  experiment?: Experiment;
-  data?: VariationData;
-  activate: () => void;
-  deactivate: () => void;
+export interface ExperimentResults<T = any> {
+  value: T;
+  index: number;
+  inExperiment: boolean;
+  experiment?: Experiment<T>;
 }
 
-export interface DataLookupResults<T = unknown> {
-  experiment?: Experiment;
-  variation?: number;
+export interface DataLookupResults<T = any> {
+  experiment?: Experiment<T>;
+  index?: number;
   value: T | undefined;
 }
 
-export interface VariationInfo {
-  key?: string;
-  weight?: number;
-  data?: {
-    [key: string]: unknown;
-  };
-  dom?: DeclarativeMutation[];
-  css?: string;
-  activate?: () => void;
-  deactivate?: () => void;
-}
-
-export interface Experiment {
+export interface Experiment<T> {
   key: string;
-  variations: number | VariationInfo[];
-  auto?: boolean;
+  variations: T[];
+  weights?: number[];
   anon?: boolean;
   status?: 'draft' | 'running' | 'stopped';
   force?: number;
@@ -60,16 +39,22 @@ export interface Experiment {
   url?: string;
 }
 
-export type TrackExperimentFunctionProps = {
-  experiment: Experiment;
-  variation: number;
-  variationKey: string;
+export interface ExperimentOverride {
+  weights?: number[];
+  status?: 'draft' | 'running' | 'stopped';
+  force?: number;
+  coverage?: number;
+  targeting?: string[];
+  url?: string;
+}
+
+export type TrackExperimentFunctionProps<T = any> = {
+  experiment: Experiment<T>;
+  value: T;
+  index: number;
   userId?: string;
   anonId?: string;
-  data?: VariationData;
   userAttributes?: UserAttributes;
-  dom?: DeclarativeMutation[];
-  css?: string;
 };
 
 export type TrackExperimentFunction = (
@@ -79,6 +64,7 @@ export type TrackExperimentFunction = (
 export interface ClientConfigInterface {
   url?: string;
   debug?: boolean;
+  qa?: boolean;
   onExperimentViewed?: TrackExperimentFunction;
   enableQueryStringOverride?: boolean;
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -19,7 +19,7 @@ export default class GrowthBookUser {
     string,
     {
       assigned: number;
-      possible: number;
+      possible: any[];
     }
   > = new Map();
   private subscriptions: Set<() => void> = new Set();
@@ -72,7 +72,9 @@ export default class GrowthBookUser {
 
   subscribe(cb: () => void) {
     this.subscriptions.add(cb);
-    return () => this.subscriptions.delete(cb);
+    return () => {
+      this.subscriptions.delete(cb);
+    };
   }
 
   private alertSubscribers() {
@@ -149,9 +151,7 @@ export default class GrowthBookUser {
       if (this.assignedVariations.get(experiment.key)?.assigned !== variation) {
         this.assignedVariations.set(experiment.key, {
           assigned: variation,
-          possible: Array.isArray(experiment.variations)
-            ? experiment.variations.length
-            : experiment.variations,
+          possible: experiment.variations,
         });
         this.alertSubscribers();
       }

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,16 +1,9 @@
-import {
-  UserAttributes,
-  VariationData,
-  Experiment,
-  ExperimentResults,
-  DataLookupResults,
-} from './types';
+import { UserAttributes, Experiment, ExperimentResults } from './types';
 import {
   checkRule,
   getWeightsFromOptions,
   chooseVariation,
   getQueryStringOverride,
-  applyDomMods,
   urlIsValid,
 } from './util';
 import GrowthBookClient from 'client';
@@ -19,10 +12,17 @@ export default class GrowthBookUser {
   private id: string;
   private anonId: string;
   private attributes: UserAttributes;
-  private client: GrowthBookClient;
+  client: GrowthBookClient;
   private experimentsTracked: Set<string>;
   private attributeMap: Map<string, string>;
-  private activeExperiments: ExperimentResults[] = [];
+  private assignedVariations: Map<
+    string,
+    {
+      assigned: number;
+      possible: number;
+    }
+  > = new Map();
+  private subscriptions: Set<() => void> = new Set();
 
   constructor(
     id: string,
@@ -38,7 +38,6 @@ export default class GrowthBookUser {
     this.experimentsTracked = new Set();
     this.attributeMap = new Map();
     this.updateAttributeMap();
-    this.refreshActiveExperiments();
   }
 
   setAttributes(attributes: UserAttributes, merge: boolean = false) {
@@ -49,7 +48,6 @@ export default class GrowthBookUser {
     }
 
     this.updateAttributeMap();
-    this.refreshActiveExperiments();
     return this;
   }
 
@@ -57,14 +55,13 @@ export default class GrowthBookUser {
     return this.attributes;
   }
 
-  deactivateAllExperiments() {
-    // Deactivate any active experiments and cleanup for GC
-    this.activeExperiments.forEach(exp => exp.deactivate());
-    this.activeExperiments = [];
-  }
-
   destroy() {
-    this.deactivateAllExperiments();
+    // Remove all subscriptions
+    this.subscriptions.clear();
+
+    // Clean up maps
+    this.assignedVariations.clear();
+    this.attributeMap.clear();
 
     // Remove user from client
     const index = this.client.users.indexOf(this);
@@ -73,44 +70,13 @@ export default class GrowthBookUser {
     }
   }
 
-  refreshActiveExperiments() {
-    // Only in browser environment
-    if (typeof window === 'undefined') return;
+  subscribe(cb: () => void) {
+    this.subscriptions.add(cb);
+    return () => this.subscriptions.delete(cb);
+  }
 
-    this.log('Refreshing active experiments');
-
-    // First see if any currently active experiments need to be deactivated
-    const activeIds: Set<string> = new Set();
-    const deactivatedIds: Set<string> = new Set();
-    this.activeExperiments.forEach(res => {
-      if (!res.experiment || res.variation === -1) return;
-
-      const newRes = this.runExperiment(res.experiment);
-      if (newRes.variation === -1) {
-        this.log(
-          'No longer in experiment ' + res.experiment.key + ', deactivating'
-        );
-        // Remove any dom/css changes and remove from active list
-        res.deactivate();
-        deactivatedIds.add(res.experiment.key);
-      } else {
-        activeIds.add(res.experiment.key);
-      }
-    });
-
-    // Then, add in any new experiments
-    this.client.experiments.forEach(exp => {
-      // Skip ones that have already been activated or were just deactivated
-      if (activeIds.has(exp.key)) return;
-      if (deactivatedIds.has(exp.key)) return;
-
-      // Must be marked as auto, targeting based on url, and have variation info
-      if (!exp.auto || !exp.url || !Array.isArray(exp.variations)) return;
-
-      // Put user in experiment and apply any dom/css mods
-      const res = this.runExperiment(exp);
-      res.activate();
-    });
+  private alertSubscribers() {
+    this.subscriptions.forEach(s => s());
   }
 
   private log(msg: string) {
@@ -122,8 +88,11 @@ export default class GrowthBookUser {
     }
   }
 
-  private isIncluded(experiment: Experiment): boolean {
-    const numVariations = this.getNumVariations(experiment);
+  private isIncluded<T>(experiment: Experiment<T>): boolean {
+    const isForced =
+      'force' in experiment || this.client.forcedVariations.has(experiment.key);
+
+    const numVariations = experiment.variations.length;
     if (numVariations < 2) {
       this.log(
         'variations must be at least 2, but only set to ' + numVariations
@@ -131,13 +100,13 @@ export default class GrowthBookUser {
       return false;
     }
 
-    if (experiment.status === 'draft') {
+    if (experiment.status === 'draft' && !isForced) {
       this.log('experiment in draft mode');
       return false;
     }
 
-    if (experiment.status === 'stopped' && !('force' in experiment)) {
-      this.log('experiment is stopped and no variation is forced');
+    if (experiment.status === 'stopped' && !isForced) {
+      this.log('experiment is stopped');
       return false;
     }
 
@@ -171,70 +140,37 @@ export default class GrowthBookUser {
     return true;
   }
 
-  private getExperimentResults(
-    experiment?: Experiment,
+  private getExperimentResults<T>(
+    experiment?: Experiment<T>,
     variation: number = -1
   ): ExperimentResults {
-    let activate: () => void = () => {};
-    let deactivate: () => void = () => {};
-
-    if (variation >= 0 && experiment && Array.isArray(experiment.variations)) {
-      const info = experiment.variations[variation];
-      const key = experiment.key;
-      let revert: () => void;
-      activate = () => {
-        // Ignore if already active
-        if (this.activeExperiments.includes(res)) return;
-
-        // Add to active list
-        this.activeExperiments.push(res);
-
-        if (info.activate) {
-          this.log('Running custom activate function for ' + key);
-          info.activate();
-        }
-        if (info.dom || info.css) {
-          this.log('Applying DOM/CSS mods for ' + key);
-          revert = applyDomMods({
-            dom: info.dom,
-            css: info.css,
-          });
-        }
-      };
-      deactivate = () => {
-        if (revert) {
-          this.log('Reverting DOM/CSS changes for ' + key);
-          revert();
-        }
-        if (info.deactivate) {
-          this.log('Running custom deactivate function for ' + key);
-          info.deactivate();
-        }
-
-        // Remove from active list
-        const index = this.activeExperiments.indexOf(res);
-        if (index !== -1) {
-          this.activeExperiments.splice(index, 1);
-        }
-      };
+    // Update the variation the user was assigned
+    if (experiment && variation >= 0) {
+      if (this.assignedVariations.get(experiment.key)?.assigned !== variation) {
+        this.assignedVariations.set(experiment.key, {
+          assigned: variation,
+          possible: Array.isArray(experiment.variations)
+            ? experiment.variations.length
+            : experiment.variations,
+        });
+        this.alertSubscribers();
+      }
     }
 
-    const res = {
-      variation,
+    const index = variation >= 0 ? variation : 0;
+
+    return {
       experiment,
-      data: experiment
-        ? this.getVariationData(experiment, variation)
-        : undefined,
-      activate,
-      deactivate,
+      inExperiment: variation >= 0,
+      index,
+      value: experiment ? experiment.variations[index] : undefined,
     };
-    return res;
   }
 
-  private runExperiment(
-    experiment: Experiment,
+  private runExperiment<T>(
+    experiment: Experiment<T>,
     isOverride: boolean = false
-  ): ExperimentResults {
+  ): ExperimentResults<T> {
     this.log('Trying to put user in experiment ' + experiment.key);
 
     if (isOverride) {
@@ -263,10 +199,23 @@ export default class GrowthBookUser {
       return this.getExperimentResults(experiment);
     }
 
+    // Forced via a client override
+    if (this.client.forcedVariations.has(experiment.key)) {
+      return this.getExperimentResults(
+        experiment,
+        this.client.forcedVariations.get(experiment.key)
+      );
+    }
+
     // Experiment variation is forced
     if (experiment.force !== undefined && experiment.force !== null) {
       this.log('variation forced to ' + experiment.force);
       return this.getExperimentResults(experiment, experiment.force);
+    }
+
+    if (this.client.config.qa) {
+      this.log('client is in qa mode, assigning variation -1');
+      return this.getExperimentResults(experiment);
     }
 
     const weights = getWeightsFromOptions(experiment);
@@ -282,95 +231,17 @@ export default class GrowthBookUser {
     return this.getExperimentResults(experiment, variation);
   }
 
-  private getNumVariations(experiment: Experiment) {
-    return Array.isArray(experiment.variations)
-      ? experiment.variations.length
-      : experiment.variations;
-  }
-
-  experiment(experiment: Experiment): ExperimentResults {
-    // Look for overrides in the client
-    const override = this.client.experiments
-      .filter(e => e.key === experiment.key)
-      .pop();
+  experiment<T>(experiment: Experiment<T>): ExperimentResults<T> {
+    const override = this.client.overrides.get(experiment.key);
     if (override) {
-      // Make sure override has same number of variations
-      if (
-        this.getNumVariations(experiment) === this.getNumVariations(override)
-      ) {
-        return this.runExperiment(override, true);
-      }
-
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(
-          'Experiment override in client has a different number of variations from the inline definition - ' +
-            experiment.key
-        );
-      }
+      const exp = {
+        ...experiment,
+        ...override,
+      };
+      return this.runExperiment(exp, true);
     }
 
     return this.runExperiment(experiment);
-  }
-
-  getFeatureFlag<T = any>(key: string): DataLookupResults<T> {
-    this.log('Looking up experiments that define data for ' + key);
-
-    // Experiments turned off globally
-    if (!this.client.isEnabled()) {
-      this.log('client is not enabled, returning immediately');
-      return {
-        experiment: undefined,
-        variation: undefined,
-        value: undefined,
-      };
-    }
-
-    if (this.client.experiments) {
-      for (let i = 0; i < this.client.experiments.length; i++) {
-        const exp = this.client.experiments[i];
-        if (
-          Array.isArray(exp.variations) &&
-          exp.variations.filter(v => v.data && key in v.data).length > 0
-        ) {
-          const ret = this.runExperiment(exp);
-          if (ret.variation >= 0) {
-            if (ret.data && key in ret.data) {
-              this.log('Using value from variation: ' + ret.data[key]);
-              return {
-                experiment: exp,
-                variation: ret.variation,
-                value: ret.data[key] as T,
-              };
-            } else {
-              this.log('No value defined for variation');
-              return {
-                experiment: exp,
-                variation: ret.variation,
-                value: undefined,
-              };
-            }
-          }
-        }
-      }
-    }
-
-    this.log('No experiments found for the data key');
-
-    return {
-      experiment: undefined,
-      variation: undefined,
-      value: undefined,
-    };
-  }
-
-  private getVariationData(
-    experiment: Experiment,
-    variation: number
-  ): VariationData {
-    if (!Array.isArray(experiment.variations)) return {};
-    // If user is not in the experiment, return the control data
-    if (variation === -1) return experiment.variations[0]?.data || {};
-    return experiment.variations[variation]?.data || {};
   }
 
   private isTargeted(rules: string[]): boolean {
@@ -401,6 +272,12 @@ export default class GrowthBookUser {
     }
     return [{ k: prefix, v: '' + val }];
   }
+
+  getAssignedVariations() {
+    return new Map(this.assignedVariations);
+  }
+  getExperiments() {}
+
   private updateAttributeMap() {
     this.attributeMap.clear();
     this.flattenUserValues('', this.attributes).forEach(({ k, v }) => {
@@ -408,8 +285,8 @@ export default class GrowthBookUser {
     });
   }
 
-  private trackView(
-    experiment: Experiment,
+  private trackView<T>(
+    experiment: Experiment<T>,
     variation: number,
     userId: string,
     anon?: boolean
@@ -422,16 +299,10 @@ export default class GrowthBookUser {
       this.experimentsTracked.add(userId + experiment.key);
 
       if (this.client.config.onExperimentViewed) {
-        const variationKey =
-          (Array.isArray(experiment.variations)
-            ? experiment.variations[variation]?.key
-            : null) || '' + variation;
-
         this.client.config.onExperimentViewed({
           experiment,
-          variation,
-          variationKey,
-          data: this.getVariationData(experiment, variation),
+          index: variation,
+          value: experiment.variations[variation],
           [anon ? 'anonId' : 'userId']: userId,
           userAttributes: this.attributes,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,11 +3317,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-mutator@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.3.1.tgz#811fe5752a44e15cb9387cd03fda074fc8ae7c4f"
-  integrity sha512-D0kuzLjY9jj6oBeebwIk6ckhQRGB5zOX5CVN+ArNuSuT7chzRFWasc0RH3S7ir/a3gPHhYhXGZ2mxVMDn7eGvg==
-
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"


### PR DESCRIPTION
Changes:
-  `experiment.variations` is now an array of arbitrary values. One of them is chosen and assigned to the user.
-  Merge together and simplify the different implementation options.
-  Client overrides can now only override a subset of experiment fields.
-  Remove dom manipulation and feature flags from the core library.