### PR TITLE
Make hashing robust to coverage changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Powerful A/B testing for JavaScript.
 
-![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.27KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
+![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.26KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
 
 -  **No external dependencies**
 -  **Lightweight and fast**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Powerful A/B testing for JavaScript.
 
-![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.28KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
+![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.27KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
 
 -  **No external dependencies**
 -  **Lightweight and fast**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Powerful A/B testing for JavaScript.
 
-![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.26KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
+![Build Status](https://github.com/growthbook/growthbook-js/workflows/Build/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-1.28KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
 
 -  **No external dependencies**
 -  **Lightweight and fast**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Context, Experiment, Result, SubscriptionFunction } from './types';
 import {
   getUrlRegExp,
   isIncluded,
-  getWeightsFromOptions,
+  getBucketRanges,
   hashFnv32a,
   chooseVariation,
   getQueryStringOverride,
@@ -180,11 +180,15 @@ export default class GrowthBook {
     // 14. Compute a hash
     const n = (hashFnv32a(hashValue + experiment.key) % 1000) / 1000;
 
-    // 15. Default to equal weights and apply coverage
-    const weights = getWeightsFromOptions(experiment);
+    // 15. Get bucket ranges
+    const ranges = getBucketRanges(
+      experiment.variations.length,
+      experiment.coverage || 1,
+      experiment.weights
+    );
 
     // 16. Assign a variation
-    const assigned = chooseVariation(n, weights);
+    const assigned = chooseVariation(n, ranges);
 
     // 17. Return if not in experiment
     if (assigned < 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,5 @@ export type SubscriptionFunction = (
   experiment: Experiment<any>,
   result: Result<any>
 ) => void;
+
+export type VariationRange = [number, number];

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { VariationRange } from 'types';
+
 export function hashFnv32a(str: string): number {
   let hval = 0x811c9dc5;
   const l = str.length;
@@ -10,13 +12,9 @@ export function hashFnv32a(str: string): number {
   return hval >>> 0;
 }
 
-export function chooseVariation(n: number, ranges: [number, number][]): number {
+export function chooseVariation(n: number, ranges: VariationRange[]): number {
   for (let i = 0; i < ranges.length; i++) {
-    if (
-      ranges[i][0] !== ranges[i][1] &&
-      n >= ranges[i][0] &&
-      n < ranges[i][1]
-    ) {
+    if (n >= ranges[i][0] && n < ranges[i][1]) {
       return i;
     }
   }
@@ -41,7 +39,7 @@ export function getBucketRanges(
   numVariations: number,
   coverage: number = 1,
   weights?: number[]
-) {
+): VariationRange[] {
   // Make sure coverage is within bounds
   if (coverage < 0) {
     if (process.env.NODE_ENV !== 'production') {
@@ -77,13 +75,12 @@ export function getBucketRanges(
   }
 
   // Covert weights to ranges
-  const ranges: [number, number][] = [];
-  let start = 0;
-  weights.forEach(w => {
-    ranges.push([start, start + coverage * w]);
-    start += w;
-  });
-  return ranges;
+  let cumulative = 0;
+  return weights.map(w => {
+    const start = cumulative;
+    cumulative += w;
+    return [start, start + coverage * w];
+  }) as VariationRange[];
 }
 
 export function getQueryStringOverride(id: string, url: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,10 +31,6 @@ export function getUrlRegExp(regexString: string): RegExp | null {
   }
 }
 
-export function getEqualWeights(n: number): number[] {
-  return new Array(n).fill(1 / n);
-}
-
 export function getBucketRanges(
   numVariations: number,
   coverage: number = 1,
@@ -54,7 +50,7 @@ export function getBucketRanges(
   }
 
   // Default to equal weights if missing or invalid
-  const equal = getEqualWeights(numVariations);
+  const equal = new Array(numVariations).fill(1 / numVariations);
   weights = weights || equal;
   if (weights.length !== numVariations) {
     if (process.env.NODE_ENV !== 'production') {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -134,7 +134,6 @@ describe('experiments', () => {
     expect(chooseVariation(0.8, evenRange)).toEqual(1);
     expect(chooseVariation(0, evenRange)).toEqual(0);
     expect(chooseVariation(0.5, evenRange)).toEqual(1);
-    expect(chooseVariation(1, evenRange)).toEqual(-1);
 
     expect(chooseVariation(0.2, reducedRange)).toEqual(0);
     expect(chooseVariation(0.6, reducedRange)).toEqual(1);


### PR DESCRIPTION
When we hash a userId and experimentKey, we get a float from 0 to 1 and that's used to assign a variation.

A 50/50 test at full coverage would have the variation ranges `[0,0.5], [0.5,1]`.  If coverage was reduced to 20%, the variation ranges would become `[0,0.1], [0.1,0.2]`.  That means someone with a hash value of `0.15` would swap variations as the coverage changed.  This is not ideal when ramping up or down traffic for a test.

This PR changes the algorithm slightly.  Now, the start of each range stays the same, no matter how coverage changes.  So when reduced to 20% coverage, the ranges would become: `[0,0.1], [0.5,0.6]`.  With this change, as long as the relative weighting between variations stays the same, the user will keep the same variation (or be excluded from the test entirely)

This is not backwards compatible since at reduced coverage, different users will be included in the experiment.  Before updating, stop all experiments running with reduced coverage.